### PR TITLE
parse-it 1.0.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 
-# parse-it [![PayPal](https://img.shields.io/badge/%24-paypal-f39c12.svg)][paypal-donations] [![Version](https://img.shields.io/npm/v/parse-it.svg)](https://www.npmjs.com/package/parse-it) [![Downloads](https://img.shields.io/npm/dt/parse-it.svg)](https://www.npmjs.com/package/parse-it) [![Get help on Codementor](https://cdn.codementor.io/badges/get_help_github.svg)](https://www.codementor.io/johnnyb?utm_source=github&utm_medium=button&utm_term=johnnyb&utm_campaign=github)
+# parse-it
+
+ [![PayPal](https://img.shields.io/badge/%24-paypal-f39c12.svg)][paypal-donations] [![AMA](https://img.shields.io/badge/ask%20me-anything-1abc9c.svg)](https://github.com/IonicaBizau/ama) [![Version](https://img.shields.io/npm/v/parse-it.svg)](https://www.npmjs.com/package/parse-it) [![Downloads](https://img.shields.io/npm/dt/parse-it.svg)](https://www.npmjs.com/package/parse-it) [![Get help on Codementor](https://cdn.codementor.io/badges/get_help_github.svg)](https://www.codementor.io/johnnyb?utm_source=github&utm_medium=button&utm_term=johnnyb&utm_campaign=github)
 
 > Configurable string templating, without separators.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parse-it",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Configurable string templating, without separators.",
   "main": "lib/index.js",
   "scripts": {
@@ -32,6 +32,7 @@
     "src/",
     "resources/",
     "menu/",
+    "scripts/",
     "cli.js",
     "index.js"
   ]


### PR DESCRIPTION
- Updated the README.md following the new template. :memo:
- Use [`babel-it`](https://github.com/IonicaBizau/babel-it) to babelify the code, so the module is now compatible with older versions of Node.js.
